### PR TITLE
Fix index out of bounds for unknown command

### DIFF
--- a/modules/commands.py
+++ b/modules/commands.py
@@ -9,7 +9,10 @@ def get_command_from_input(user, input_):
     if len(command) == 0 and (user.is_god() or user.is_builder()):
         command = [c for c in GOD_COMMAND_LIST
                    if c[0].startswith(input_)]
-    return command[0]
+    if len(command) == 0:
+        return None
+    else:
+        return command[0]
 
 async def process(user, input_):
     input_ = input_.strip()
@@ -19,7 +22,7 @@ async def process(user, input_):
         user.add_message('')
         return
     command = get_command_from_input(user, userCommand)
-    if len(command) == 0:
+    if not command:
         user.add_message('Unknown command: {}'.format(userCommand))
         return
 

--- a/modules/commands.py
+++ b/modules/commands.py
@@ -100,7 +100,7 @@ async def help_command(user, remainder, **kwargs):
                          '{}'.format(command_list))
         return
     command = get_command_from_input(user, remainder[0])
-    if len(command) == 0:
+    if not command:
         user.add_message("I can't help you with {}".format(remainder[0]))
         return
     help_message = command[2]


### PR DESCRIPTION
An unknown user command makes `command` in `get_command_from_input` a
zero length array, subsequent access to `command[0]` causes exception to
be thrown on server. We should only access `command[0]` when the array
has at least one element.